### PR TITLE
Fix Necto/Nexto on non-ascii paths

### DIFF
--- a/RLBotPack/Necto/Necto/agent.py
+++ b/RLBotPack/Necto/Necto/agent.py
@@ -10,7 +10,8 @@ from torch.distributions import Categorical
 class Agent:
     def __init__(self):
         cur_dir = os.path.dirname(os.path.realpath(__file__))
-        self.actor = torch.jit.load(os.path.join(cur_dir, "necto-model.pt"))
+        with open(os.path.join(cur_dir, "necto-model.pt"), 'rb') as f:
+            self.actor = torch.jit.load(f)
         torch.set_num_threads(1)
 
     def act(self, state, beta):

--- a/RLBotPack/Necto/Nexto/agent.py
+++ b/RLBotPack/Necto/Nexto/agent.py
@@ -10,7 +10,8 @@ from torch.distributions import Categorical
 class Agent:
     def __init__(self):
         cur_dir = os.path.dirname(os.path.realpath(__file__))
-        self.actor = torch.jit.load(os.path.join(cur_dir, "nexto-model.pt"))
+        with open(os.path.join(cur_dir, "nexto-model.pt"), 'rb') as f:
+            self.actor = torch.jit.load(f)
         torch.set_num_threads(1)
         self._lookup_table = self.make_lookup_table()
         self.state = None


### PR DESCRIPTION
Many users have non-ascii windows usernames and because botpack is located at %appdata% the path contains the username.

`torch.jit.load(path)` fails with non-ascii paths (https://github.com/pytorch/pytorch/issues/75171). Until that is fixed, the workaround is opening the file with `open(path, "rb")` and passing the file object to `torch.jit.load` instead.