### PR TITLE
made jit calls more lenient

### DIFF
--- a/RLBotPack/Kamael_family/impossibum_utilities.py
+++ b/RLBotPack/Kamael_family/impossibum_utilities.py
@@ -7286,7 +7286,6 @@ def normalize(v):
         float32,
         typeof(False),
     ),
-    nopython=True,
     cache=True,
 )
 def jumpSimulatorNormalizingJit(


### PR DESCRIPTION
I was forcing nopython = True on jitted functions which causes errors whenever a function can't be compiled in that mode for any reason. With that removed it should fail compiling and then fallback to python mode which is better than the bot not functioning at all. So performance gains are maintained on computers than can compile properly and at least diminished functionality is permitted to those that can't.