### PR TITLE
Bump torch to 2.0.1, fix sb3 w special gym ver, and remove pickle5 requirements

### DIFF
--- a/RLBotPack/Element/requirements.txt
+++ b/RLBotPack/Element/requirements.txt
@@ -2,7 +2,7 @@
 # You will automatically get updates for all versions starting with "1.".
 rlbot==1.*
 --find-links https://download.pytorch.org/whl/torch_stable.html
-torch==1.9.1+cpu
+torch==2.0.1+cpu
 numpy
 
 # This will cause pip to auto-upgrade and stop scaring people with warning messages

--- a/RLBotPack/Engine/Engine/requirements.txt
+++ b/RLBotPack/Engine/Engine/requirements.txt
@@ -2,12 +2,10 @@
 # You will automatically get updates for all versions starting with "1.".
 rlbot==1.*
 --find-links https://download.pytorch.org/whl/torch_stable.html
-torch==1.9.1+cpu
+torch==2.0.1+cpu
 stable_baselines3
 rlgym-compat
 numpy
-pickle5
-cloudpickle
 gym
 # This will cause pip to auto-upgrade and stop scaring people with warning messages
 pip

--- a/RLBotPack/Immortal/requirements.txt
+++ b/RLBotPack/Immortal/requirements.txt
@@ -2,7 +2,7 @@
 # You will automatically get updates for all versions starting with "1.".
 rlbot==1.*
 --find-links https://download.pytorch.org/whl/torch_stable.html
-torch==1.9.1+cpu
+torch==2.0.1+cpu
 rlgym-compat>=1.0.2
 numpy
 

--- a/RLBotPack/Levi/requirements.txt
+++ b/RLBotPack/Levi/requirements.txt
@@ -1,4 +1,4 @@
 numpy
 RLUtilities
-torch==1.6.0+cpu
+torch==2.0.1+cpu
 -f https://download.pytorch.org/whl/torch_stable.html

--- a/RLBotPack/Monkey/requirements.txt
+++ b/RLBotPack/Monkey/requirements.txt
@@ -2,8 +2,10 @@
 # You will automatically get updates for all versions starting with "1.".
 rlbot==1.*
 --find-links https://download.pytorch.org/whl/torch_stable.html
-torch==1.9.1+cpu
+torch==2.0.1+cpu
 rlgym-compat>=1.0.2
+gym @ git+https://github.com/openai/gym.git@9180d12e1b66e7e2a1a622614f787a6ec147ac40
+stable_baselines==1.7.0
 numpy
 
 # This will cause pip to auto-upgrade and stop scaring people with warning messages

--- a/RLBotPack/Necto/Necto/requirements.txt
+++ b/RLBotPack/Necto/Necto/requirements.txt
@@ -2,7 +2,7 @@
 # You will automatically get updates for all versions starting with "1.".
 rlbot==1.*
 --find-links https://download.pytorch.org/whl/torch_stable.html
-torch==1.9.1+cpu
+torch==2.0.1+cpu
 rlgym-compat==1.0.2
 numpy
 

--- a/RLBotPack/Necto/Nexto/requirements.txt
+++ b/RLBotPack/Necto/Nexto/requirements.txt
@@ -2,7 +2,7 @@
 # You will automatically get updates for all versions starting with "1.".
 rlbot==1.*
 --find-links https://download.pytorch.org/whl/torch_stable.html
-torch==1.9.1+cpu
+torch==2.0.1+cpu
 rlgym-compat==1.0.2
 numpy
 

--- a/RLBotPack/Necto/Nexto_EZ/requirements.txt
+++ b/RLBotPack/Necto/Nexto_EZ/requirements.txt
@@ -2,7 +2,7 @@
 # You will automatically get updates for all versions starting with "1.".
 rlbot==1.*
 --find-links https://download.pytorch.org/whl/torch_stable.html
-torch==1.9.1+cpu
+torch==2.0.1+cpu
 rlgym-compat==1.0.2
 numpy
 shared-memory38

--- a/RLBotPack/Omus/requirements.txt
+++ b/RLBotPack/Omus/requirements.txt
@@ -2,12 +2,10 @@
 # You will automatically get updates for all versions starting with "1.".
 rlbot==1.*
 --find-links https://download.pytorch.org/whl/torch_stable.html
-torch==1.9.1+cpu
+torch==2.0.1+cpu
 stable-baselines3
 rlgym-compat>=1.0.2
 numpy
-pickle5
-cloudpickle
 keyboard
 pygame
 pathlib

--- a/RLBotPack/Seer/helper.py
+++ b/RLBotPack/Seer/helper.py
@@ -48,7 +48,7 @@ def invert_yaw(yaw):
     return yaw
 
 
-enc = OneHotEncoder(sparse=False, drop='if_binary',
+enc = OneHotEncoder(sparse_output=False, drop='if_binary',
                     categories=[np.array([0., 1., 2.]), np.array([0., 1., 2., 3., 4.]), np.array([0., 1., 2., 3., 4.]), np.array([0., 1., 2.]), np.array([0., 1.]), np.array([0., 1.]),
                                 np.array([0., 1.])])
 

--- a/RLBotPack/Seer/requirements.txt
+++ b/RLBotPack/Seer/requirements.txt
@@ -2,7 +2,7 @@
 # You will automatically get updates for all versions starting with "1.".
 rlbot==1.*
 --find-links https://download.pytorch.org/whl/torch_stable.html
-torch==1.9.1+cpu
+torch==2.0.1+cpu
 numpy
 scikit-learn
 numba

--- a/RLBotPack/Vector/requirements.txt
+++ b/RLBotPack/Vector/requirements.txt
@@ -2,11 +2,11 @@
 # You will automatically get updates for all versions starting with "1.".
 rlbot==1.*
 --find-links https://download.pytorch.org/whl/torch_stable.html
-torch==1.9.1+cpu
+torch==2.0.1+cpu
 rlgym-compat>=1.0.2
 numpy
-stable-baselines3
-pickle5
+gym @ git+https://github.com/openai/gym.git@9180d12e1b66e7e2a1a622614f787a6ec147ac40
+stable-baselines3==1.7.0
 
 # This will cause pip to auto-upgrade and stop scaring people with warning messages
 pip


### PR DESCRIPTION
In preparation for Python 3.11, the torch version have been bumped to 2.0.1. I also took the opportunity to fix the bots requiring a special version of gym/sb3. Lastly, pickle5 is not need in 3.11.