### PR TITLE
Rename Seer to Seer v0

### DIFF
--- a/RLBotPack/Seer/bot.cfg
+++ b/RLBotPack/Seer/bot.cfg
@@ -6,7 +6,7 @@ looks_config = ./appearance.cfg
 python_file = ./bot.py
 
 # Name of the bot in-game
-name = Seer
+name = Seer v0
 
 logo_file = ./logo.png
 


### PR DESCRIPTION
This rename might prevent some people from being confused when Seer isn't SSL level like v6/7 is.